### PR TITLE
Adding a test waiter to prevent race conditions in acceptance tests

### DIFF
--- a/test-support/helpers.js
+++ b/test-support/helpers.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+/**
+ * Testing helper to determine whether or not the scheduler services queues have been drained
+ *
+ * This function is useful for testing, because the default ember async wait helper will not
+ * wait until the 'afterFirstRoutePaint' and 'afterContentPaint' queues have been drained,
+ * which will cause race conditions for anything using this scheduler.
+ *
+ * @param app {Application} Ember testing Application
+ * @param queueName {String} name of the queue to check emptiness for (i.e afterContentPaint)
+ * @return {Boolean} whether or not the queueName queue is empty.
+ */
+export default function isQueueDrained(app, queueName) {
+  const schedulerService = app.__container__.lookup('service:scheduler');
+  const queue = schedulerService.queues[queueName];
+  return queue.tasks.length === 0;
+}


### PR DESCRIPTION

**Symptom of the issues we ran into while using the ember-app-scheduler**

Many of our lazy-loaded features are now flaky in tests. Sometimes they are rendered, and sometimes they are not.

**Root cause of the issue**

Recently (within the past few weeks) we changed our lazy-load feed code to use afterFirstRoutePaint from the ember-app-scheduler https://github.com/sreedhar7/ember-app-scheduler, rather than the default ember run loop.

**Before the change above**

The lazy-loading of the our feed would occur before the paint, and thus, the ember andThen test helper was able to wait for the lazy-loaded feed to complete. Once the test hit andThen, the feed and recent update were successfully loaded.

**Afer the change above**

The lazy-loading of the feed would occur after the paint, so the page is rendered and the andThen test helper started executing. This caused a race condition between the time it took the lazy-loaded feed to finish and when the test actually got to asserting that. Because it's a test, the lazy loading of the feed is extremely fast due to mock data, and this race condition didn't cause us problems until now.

**Proposed Solution**

Step 1: Add an API to the ember-app-scheduler to see if the queues are empty or not
Step2: Register a waiter in our application to ensure that the queues are empty before asserting