### PR TITLE
Fix test-waiter early return.

### DIFF
--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -174,7 +174,7 @@ if (DEBUG) {
       if (Ember.testing) {
         this._waiter = () => {
           if (!this.queues) {
-            return;
+            return true;
           }
           const lastQueueName = this.queueNames[this.queueNames.length - 1];
           const lastQueue = this.queues[lastQueueName];


### PR DESCRIPTION
When we do not have any queues, we need to return `true` to let the waiter know we have finished.

I opened this PR from the web-client so unfortunately it was a bit hard to add a test; however, we should add a test for what happens when the queues are never used because it seems we do not hit that case.