### PR TITLE
Refactoring queues to look more like queues

### DIFF
--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -45,7 +45,7 @@ const Scheduler = Service.extend({
     const queue = this.queues[queueName];
     queue.isActive = false;
 
-    while (queue.tasks.length) {
+    while (queue.size() > 0) {
       const task = queue.dequeue();
 
       if (!task.token.cancelled) {

--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -43,15 +43,7 @@ const Scheduler = Service.extend({
 
   flushQueue(queueName) {
     const queue = this.queues[queueName];
-    queue.isActive = false;
-
-    while (queue.size() > 0) {
-      const task = queue.dequeue();
-
-      if (!task.token.cancelled) {
-        task.callback();
-      }
-    }
+    queue.flush();
 
     this._afterNextPaint()
       .then(() => {

--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import { DEBUG } from '@glimmer/env';
-import Token from '../token';
 import TaskQueue from '../task-queue';
 
 const {
@@ -26,19 +25,20 @@ const Scheduler = Service.extend({
 
   scheduleWork(queueName, callback) {
     const queue = this.queues[queueName];
-    const token = new Token();
 
     if (queue.isActive) {
-      queue.enqueue({token, callback});
+      queue.enqueue(callback);
     } else {
       callback();
     }
 
-    return token;
+    return callback;
   },
 
-  cancelWork(token) {
-    token.cancel();
+  cancelWork(queueName, token) {
+    const queue = this.queues[queueName];
+
+    queue.cancel(token);
   },
 
   flushQueue(queueName) {

--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -46,9 +46,7 @@ const Scheduler = Service.extend({
     queue.flush();
 
     this._afterNextPaint()
-      .then(() => {
-        queue.afterPaintDeferred.resolve();
-      });
+      .then(queue.afterPaintDeferred.resolve);
   },
 
   _initQueues() {

--- a/addon/task-queue.js
+++ b/addon/task-queue.js
@@ -16,22 +16,22 @@ export default class TaskQueue {
       this.tasks.splice(index, 1);
     }
   }
-
-  size() {
-    return this.tasks.length;
-  }
-
+  
   flush() {
     this.isActive = false;
-
+    
     for (let i = 0; i < this.tasks.length; i++) {
       this.tasks[i]();
     }
-
+    
     this.tasks = [];
     this.isActive = true;
   }
-
+  
+  size() {
+    return this.tasks.length;
+  }
+  
   reset() {
     this.tasks = [];
     this.isActive = true;

--- a/addon/task-queue.js
+++ b/addon/task-queue.js
@@ -9,12 +9,19 @@ export default class TaskQueue {
     this.tasks.push(task);
   }
 
-  dequeue() {
-    return this.tasks.shift();
-  }
-
   size() {
     return this.tasks.length;
+  }
+
+  flush() {
+    this.isActive = false;
+
+    for (let i = 0; i < this.tasks.length; i++) {
+      this.tasks[i].callback();
+    }
+
+    this.tasks = [];
+    this.isActive = true;
   }
 
   reset() {

--- a/addon/task-queue.js
+++ b/addon/task-queue.js
@@ -9,6 +9,14 @@ export default class TaskQueue {
     this.tasks.push(task);
   }
 
+  cancel(token) {
+    let index = this.tasks.indexOf(token);
+    
+    if (index > -1) {
+      this.tasks.splice(index, 1);
+    }
+  }
+
   size() {
     return this.tasks.length;
   }
@@ -17,7 +25,7 @@ export default class TaskQueue {
     this.isActive = false;
 
     for (let i = 0; i < this.tasks.length; i++) {
-      this.tasks[i].callback();
+      this.tasks[i]();
     }
 
     this.tasks = [];

--- a/addon/task-queue.js
+++ b/addon/task-queue.js
@@ -1,0 +1,26 @@
+import RSVP from 'rsvp';
+
+export default class TaskQueue {
+  constructor() {
+    this.reset();    
+  }
+
+  enqueue(task) {
+    this.tasks.push(task);
+  }
+
+  dequeue() {
+    return this.tasks.shift();
+  }
+
+  size() {
+    return this.tasks.length;
+  }
+
+  reset() {
+    this.tasks = [];
+    this.isActive = true;
+    this.afterPaintDeferred = RSVP.defer();
+    this.afterPaintPromise = this.afterPaintDeferred.promise;
+  }
+}

--- a/addon/token.js
+++ b/addon/token.js
@@ -1,0 +1,14 @@
+
+export default class Token {
+    constructor() {
+      this._cancelled = false;
+    }
+  
+    get cancelled() {
+      return this._cancelled;
+    }
+  
+    cancel() {
+      this._cancelled = true;
+    }
+  }

--- a/testem.js
+++ b/testem.js
@@ -8,12 +8,15 @@ module.exports = {
   launch_in_dev: [
     'Chrome'
   ],
-  browser_args: {
-    Chrome: [
-      '--disable-gpu',
-      '--headless',
-      '--remote-debugging-port=9222',
-      '--window-size=1440,900'
-    ]
+  'browser_args': {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=9222',
+        '--window-size=1440,900'
+      ]
+    },
   }
 };

--- a/tests/dummy/app/components/defer-render.js
+++ b/tests/dummy/app/components/defer-render.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
   willDestroyElement() {
     this._super(...arguments);
     if (this._token) {
-      this.get('scheduler').cancelWork(this._token);
+      this.get('scheduler').cancelWork('afterFirstRoutePaint', this._token);
     }
   }
 });

--- a/tests/dummy/app/components/right-rail-ad.js
+++ b/tests/dummy/app/components/right-rail-ad.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
   willDestroyElement() {
     this._super(...arguments);
     if (this._token) {
-      this.get('scheduler').cancelWork(this._token);
+      this.get('scheduler').cancelWork('afterContentPaint', this._token);
     }
   }
 });

--- a/tests/unit/services/scheduler-test.js
+++ b/tests/unit/services/scheduler-test.js
@@ -29,7 +29,7 @@ test('it should have an active queue after scheduling work', function(assert) {
 
   assert.ok(this.scheduler.hasActiveQueue(), 'has active queues');
 
-  this.scheduler.cancelWork(workToken);
+  this.scheduler.cancelWork(AFTER_CONTENT_PAINT, workToken);
 });
 
 test('it should not have an active queue after flushing that queue', function(assert) {
@@ -47,7 +47,7 @@ test('it should not have an active queue after flushing that queue', function(as
 
   assert.notOk(this.scheduler.hasActiveQueue(), 'has no active queues');
 
-  this.scheduler.cancelWork(workToken);
+  this.scheduler.cancelWork(AFTER_CONTENT_PAINT, workToken);
 });
 
 test('it should have no active queues after the router\'s willTransition event', function(assert) {
@@ -65,19 +65,17 @@ test('it should have no active queues after the router\'s willTransition event',
 
   assert.notOk(this.scheduler.hasActiveQueue(), 'has no active queues');
 
-  this.scheduler.cancelWork(workToken);
+  this.scheduler.cancelWork(AFTER_CONTENT_PAINT, workToken);
 });
 
 test('it should cancel work when given a token', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   let myWork = () => true;
 
   const workToken = this.scheduler.scheduleWork(AFTER_CONTENT_PAINT, myWork);
 
-  assert.notOk(workToken.cancelled, 'token is not cancelled');
+  this.scheduler.cancelWork(AFTER_CONTENT_PAINT, workToken);
 
-  this.scheduler.cancelWork(workToken);
-
-  assert.ok(workToken.cancelled, 'token is cancelled');
+  assert.equal(this.scheduler.queues[AFTER_CONTENT_PAINT].tasks.indexOf(workToken), -1, 'token is cancelled');
 });

--- a/tests/unit/task-queue-test.js
+++ b/tests/unit/task-queue-test.js
@@ -1,0 +1,78 @@
+import { module, test } from 'qunit';
+import TaskQueue from 'ember-app-scheduler/task-queue';
+import Token from 'ember-app-scheduler/token';
+
+module(`Unit | ember-app-scheduler | Queue`, {
+  beforeEach() {
+    this.taskQueue = new TaskQueue();
+
+    this.createTask = () => {
+      return { token: new Token(), callback: () => {} };
+    }
+  }
+});
+
+test('queue size is 0 when instantiated', function(assert) {
+  assert.expect(1);
+
+  assert.equal(this.taskQueue.size(), 0, 'size is 0');
+});
+
+test('queue size is 1 when item is enqueued', function(assert) {
+  assert.expect(1);
+
+  this.taskQueue.enqueue(this.createTask());
+
+  assert.equal(this.taskQueue.size(), 1, 'size is 1');
+});
+
+test('task is enqueued', function(assert) {
+  assert.expect(1);
+
+  const task = this.createTask();
+
+  this.taskQueue.enqueue(task);
+
+  assert.equal(task, this.taskQueue.tasks[0], 'task is correctly enqueued');
+});
+
+test('task is dequeued', function(assert) {
+  assert.expect(1);
+
+  const task = this.createTask();
+
+  this.taskQueue.enqueue(task);
+  
+  const expectedTask = this.taskQueue.dequeue();
+
+  assert.equal(task, expectedTask, 'task is correctly dequeued');
+});
+
+test('task is dequeued in the correct order', function(assert) {
+  assert.expect(1);
+
+  const firstTask = this.createTask();
+  const secondTask = this.createTask();
+
+  this.taskQueue.enqueue(firstTask);
+  this.taskQueue.enqueue(secondTask);
+  
+  const expectedTask = this.taskQueue.dequeue();
+
+  assert.equal(firstTask, expectedTask, 'task is correctly dequeued');
+});
+
+test('queue is reset correctly', function(assert) {
+  assert.expect(2);
+
+  const firstTask = this.createTask();
+  const secondTask = this.createTask();
+
+  this.taskQueue.enqueue(firstTask);
+  this.taskQueue.enqueue(secondTask);
+  
+  this.taskQueue.reset();
+
+  assert.equal(this.taskQueue.size(), 0, 'size is 0');
+  assert.ok(this.taskQueue.isActive, 'size is 0');
+});

--- a/tests/unit/task-queue-test.js
+++ b/tests/unit/task-queue-test.js
@@ -1,13 +1,12 @@
 import { module, test } from 'qunit';
 import TaskQueue from 'ember-app-scheduler/task-queue';
-import Token from 'ember-app-scheduler/token';
 
 module(`Unit | ember-app-scheduler | Queue`, {
   beforeEach() {
     this.taskQueue = new TaskQueue();
 
     this.createTask = () => {
-      return { token: new Token(), callback: () => {} };
+      return () => {};
     }
   }
 });

--- a/tests/unit/task-queue-test.js
+++ b/tests/unit/task-queue-test.js
@@ -36,33 +36,7 @@ test('task is enqueued', function(assert) {
   assert.equal(task, this.taskQueue.tasks[0], 'task is correctly enqueued');
 });
 
-test('task is dequeued', function(assert) {
-  assert.expect(1);
-
-  const task = this.createTask();
-
-  this.taskQueue.enqueue(task);
-  
-  const expectedTask = this.taskQueue.dequeue();
-
-  assert.equal(task, expectedTask, 'task is correctly dequeued');
-});
-
-test('task is dequeued in the correct order', function(assert) {
-  assert.expect(1);
-
-  const firstTask = this.createTask();
-  const secondTask = this.createTask();
-
-  this.taskQueue.enqueue(firstTask);
-  this.taskQueue.enqueue(secondTask);
-  
-  const expectedTask = this.taskQueue.dequeue();
-
-  assert.equal(firstTask, expectedTask, 'task is correctly dequeued');
-});
-
-test('queue is reset correctly', function(assert) {
+test('queue flushes correctly', function(assert) {
   assert.expect(2);
 
   const firstTask = this.createTask();
@@ -71,8 +45,8 @@ test('queue is reset correctly', function(assert) {
   this.taskQueue.enqueue(firstTask);
   this.taskQueue.enqueue(secondTask);
   
-  this.taskQueue.reset();
+  this.taskQueue.flush();
 
   assert.equal(this.taskQueue.size(), 0, 'size is 0');
-  assert.ok(this.taskQueue.isActive, 'size is 0');
+  assert.ok(this.taskQueue.isActive, 'queue is active');
 });


### PR DESCRIPTION
A bit of cleanup work on making the queues look a bit more like queues. Removes the use of an array with pairs of related objects to manage the items in the queue.