### PR TITLE
Renaming scheduleWork/cancelWork to on/off respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This addon provides a service to schedule work in different paint phases of rend
 The `afterFirstRoutePaint` queue can be used to schedule work after the route is first painted. This is useful for scenarios like rendering content outside viewport, rendering non critical content etc.
 
 ```javascript
-this.get('scheduler').scheduleWork('afterFirstRoutePaint', () => {
+this.get('scheduler').on('afterFirstRoutePaint', () => {
   // schedule work
 });
 ```
@@ -25,7 +25,7 @@ this.get('scheduler').scheduleWork('afterFirstRoutePaint', () => {
 The `afterContentPaint` queue can be used to schedule work after all the important content of the page has been painted. This is useful for scenarios like rendering ads, scheduling tracking work, rendering of popup overlays etc.
 
 ```javascript
-this.get('scheduler').scheduleWork('afterContentPaint', () => {
+this.get('scheduler').on('afterContentPaint', () => {
   // schedule work
 });
 ```

--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -1,8 +1,8 @@
+import Ember from 'ember';
+import RSVP from 'rsvp';
 import { registerWaiter, unregisterWaiter } from '@ember/test';
 import { run } from '@ember/runloop';
-import RSVP from 'rsvp';
 import Service from '@ember/service';
-import Ember from 'ember';
 import { DEBUG } from '@glimmer/env';
 import TaskQueue from '../task-queue';
 
@@ -21,7 +21,7 @@ const Scheduler = Service.extend({
     this._useRAF = typeof requestAnimationFrame === 'function';
   },
 
-  scheduleWork(queueName, callback) {
+  on(queueName, callback) {
     const queue = this.queues[queueName];
 
     if (queue.isActive) {
@@ -33,7 +33,7 @@ const Scheduler = Service.extend({
     return callback;
   },
 
-  cancelWork(queueName, token) {
+  off(queueName, token) {
     const queue = this.queues[queueName];
 
     queue.cancel(token);

--- a/tests/dummy/app/components/defer-render.js
+++ b/tests/dummy/app/components/defer-render.js
@@ -9,21 +9,18 @@ export default Component.extend({
 
   init() {
     this._super();
-    this._token = this.get('scheduler').scheduleWork(
-      'afterFirstRoutePaint',
-      () => {
-        join(() => {
-          this.set('shouldRender', true);
-          this.isRendered = true;
-        });
-      }
-    );
+    this._token = this.get('scheduler').on('afterFirstRoutePaint', () => {
+      join(() => {
+        this.set('shouldRender', true);
+        this.isRendered = true;
+      });
+    });
   },
 
   willDestroyElement() {
     this._super(...arguments);
     if (this._token) {
-      this.get('scheduler').cancelWork('afterFirstRoutePaint', this._token);
+      this.get('scheduler').off('afterFirstRoutePaint', this._token);
     }
   },
 });

--- a/tests/dummy/app/components/right-rail-ad.js
+++ b/tests/dummy/app/components/right-rail-ad.js
@@ -9,21 +9,18 @@ export default Component.extend({
 
   init() {
     this._super();
-    this._token = this.get('scheduler').scheduleWork(
-      'afterContentPaint',
-      () => {
-        join(() => {
-          this.set('shouldRender', true);
-          this.isRendered = true;
-        });
-      }
-    );
+    this._token = this.get('scheduler').on('afterContentPaint', () => {
+      join(() => {
+        this.set('shouldRender', true);
+        this.isRendered = true;
+      });
+    });
   },
 
   willDestroyElement() {
     this._super(...arguments);
     if (this._token) {
-      this.get('scheduler').cancelWork('afterContentPaint', this._token);
+      this.get('scheduler').off('afterContentPaint', this._token);
     }
   },
 });

--- a/tests/unit/services/scheduler-test.js
+++ b/tests/unit/services/scheduler-test.js
@@ -32,11 +32,11 @@ module('Unit | Service | scheduler', function(hooks) {
 
     let myWork = () => true;
 
-    const workToken = this.scheduler.scheduleWork(AFTER_CONTENT_PAINT, myWork);
+    const workToken = this.scheduler.on(AFTER_CONTENT_PAINT, myWork);
 
     assert.ok(this.scheduler.hasActiveQueue(), 'has active queues');
 
-    this.scheduler.cancelWork(AFTER_CONTENT_PAINT, workToken);
+    this.scheduler.off(AFTER_CONTENT_PAINT, workToken);
   });
 
   test('it should not have an active queue after flushing that queue', function(assert) {
@@ -44,7 +44,7 @@ module('Unit | Service | scheduler', function(hooks) {
 
     let myWork = () => true;
 
-    const workToken = this.scheduler.scheduleWork(AFTER_CONTENT_PAINT, myWork);
+    const workToken = this.scheduler.on(AFTER_CONTENT_PAINT, myWork);
 
     assert.ok(this.scheduler.hasActiveQueue(), 'has active queues');
 
@@ -54,7 +54,7 @@ module('Unit | Service | scheduler', function(hooks) {
 
     assert.notOk(this.scheduler.hasActiveQueue(), 'has no active queues');
 
-    this.scheduler.cancelWork(AFTER_CONTENT_PAINT, workToken);
+    this.scheduler.off(AFTER_CONTENT_PAINT, workToken);
   });
 
   test("it should have no active queues after the router's willTransition event", function(assert) {
@@ -62,7 +62,7 @@ module('Unit | Service | scheduler', function(hooks) {
 
     let myWork = () => true;
 
-    const workToken = this.scheduler.scheduleWork(AFTER_CONTENT_PAINT, myWork);
+    const workToken = this.scheduler.on(AFTER_CONTENT_PAINT, myWork);
 
     assert.ok(this.scheduler.hasActiveQueue(), 'has active queues');
 
@@ -72,7 +72,7 @@ module('Unit | Service | scheduler', function(hooks) {
 
     assert.notOk(this.scheduler.hasActiveQueue(), 'has no active queues');
 
-    this.scheduler.cancelWork(AFTER_CONTENT_PAINT, workToken);
+    this.scheduler.off(AFTER_CONTENT_PAINT, workToken);
   });
 
   test('it should cancel work when given a token', function(assert) {
@@ -80,9 +80,9 @@ module('Unit | Service | scheduler', function(hooks) {
 
     let myWork = () => true;
 
-    const workToken = this.scheduler.scheduleWork(AFTER_CONTENT_PAINT, myWork);
+    const workToken = this.scheduler.on(AFTER_CONTENT_PAINT, myWork);
 
-    this.scheduler.cancelWork(AFTER_CONTENT_PAINT, workToken);
+    this.scheduler.off(AFTER_CONTENT_PAINT, workToken);
 
     assert.equal(
       this.scheduler.queues[AFTER_CONTENT_PAINT].tasks.indexOf(workToken),


### PR DESCRIPTION
The `scheduleWork`/`cancelWork` names feel non-standard when using this service. This PR renames them to a more conventional `on`/`off`.